### PR TITLE
Fix error preventing tooltip from showing

### DIFF
--- a/molplotly/main.py
+++ b/molplotly/main.py
@@ -330,7 +330,7 @@ def add_molecules(
                 )
 
         if title_col is not None:
-            title = df_row[title_col].astype(str)
+            title = str(df_row[title_col])
             if title_col in caption_transform:
                 title = caption_transform[title_col](title)
 


### PR DESCRIPTION
Fix for #23 - prevents "Callback error" when hovering over molecules due to `df_row[title_col]` directly returning a string with no `astype()` method.

In case the same error is occuring for anybody else, this would seem to fix it - however, if the problem is specific to my device, please disregard.