### PR TITLE
App fix for dash>=2.10

### DIFF
--- a/molplotly/main.py
+++ b/molplotly/main.py
@@ -10,7 +10,12 @@ import re
 import pandas as pd
 import numpy as np
 from dash import Input, Output, dcc, html, no_update
-from jupyter_dash import JupyterDash
+import dash
+from packaging import version
+if version.parse(dash.__version__) >= version.parse("2.11"):
+    from dash import Dash as JupyterDash
+else:
+    from jupyter_dash import JupyterDash
 from pandas.core.groupby import DataFrameGroupBy
 from plotly.graph_objects import Figure
 import plotly.graph_objects as go

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "jupyter-dash>=0.4.2",
         "plotly>=5.0.0",
         "rdkit-pypi>=2021.9.4",
+        "packaging",
         "pandas",
         "ipykernel",
         "nbformat",

--- a/setup_pip.py
+++ b/setup_pip.py
@@ -25,6 +25,7 @@ setup(
         "jupyter-dash>=0.4.2",
         "plotly>=5.0.0",
         "rdkit-pypi>=2021.9.4",
+        "packaging"
         "pandas",
         "ipykernel",
         "nbformat",


### PR DESCRIPTION
I noticed, that when molplotly used with dash>=2.10 is used then deprecation warning is raised and also plot are duplicated (as mentioned in #31 
Replacement of the `JupyterDash` with `Dash` fully solves the issue for dash>=2.10