### PR TITLE
update rdkit-pypi to rdkit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "werkzeug>=2.0.0",
         "jupyter-dash>=0.4.2",
         "plotly>=5.0.0",
-        "rdkit-pypi>=2021.9.4",
+        "rdkit",
         "pandas",
         "ipykernel",
         "nbformat",

--- a/setup_pip.py
+++ b/setup_pip.py
@@ -24,7 +24,7 @@ setup(
         "werkzeug>=2.0.0",
         "jupyter-dash>=0.4.2",
         "plotly>=5.0.0",
-        "rdkit-pypi>=2021.9.4",
+        "rdkit",
         "pandas",
         "ipykernel",
         "nbformat",


### PR DESCRIPTION
This pull request updates the dependency in molplotly from `rdkit-pypi` to `rdkit`.  Newer RDKit versions are available at the `rdkit` PyPI repository.

I ran all the example notebooks after the change, which seem to work correctly after updating to `rdkit`.